### PR TITLE
Don't discard props in `nav.push()` options hash

### DIFF
--- a/RouteNavigator.js
+++ b/RouteNavigator.js
@@ -32,6 +32,7 @@ class RouteNavigator extends React.Component {
             return this.getPage(
               route,
               nav,
+              raw,
               ref => {
                 if ( !ref ) return;
                 ref.props = { ...(ref.props || {}), ...(route.props || {}) };
@@ -76,7 +77,7 @@ class RouteNavigator extends React.Component {
     return this._pages
   }
 
-  getPage(route, nav, refCallback) {
+  getPage(route, nav, raw, refCallback) {
     var { name, props, component } = route;
 
     // Construct if needed
@@ -94,7 +95,8 @@ class RouteNavigator extends React.Component {
         app: this.props.app,
         nav,
         ref: (c) => { page.ref = c; (refCallback || (()=>{}))(c); },
-        ...(props)
+        ...(props),
+        ...(raw.props || {}),
       };
 
       // Create element


### PR DESCRIPTION
- previously was only using props defined with original route, but ignoring the ones in `.push()`

``` javascript
this.props.nav.push({
  name: '/foo/1',
  props: { someProp: 1 },
  body: { someBody: 1 },
})
```
- In the above example `this.state.query.someQuery` would be `1`, `this.state.body.someBody` would be `1`, however, `this.props.someProp` would **not be set**.
- This patch fixes this behaviour
