### PR TITLE
Bump route-parser dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "homepage": "https://github.com/Andr3wHur5t/react-native-route-navigator#readme",
   "dependencies": {
-    "route-parser": "0.0.4"
+    "route-parser": "0.0.5"
   },
   "keywords": [
     "react-component",


### PR DESCRIPTION
Route-parser isn't compatible with react-native 0.22's package manager, which seems to interact strangely with strict mode. Upgrading to the latest version of route-parser seems to fix the issue.
